### PR TITLE
Add support for arxiv and doi entries

### DIFF
--- a/mn2e.bst
+++ b/mn2e.bst
@@ -24,11 +24,8 @@
 %%     style/class (mn2e.cls or mn.sty) from Blackwell Scientific
 %%
 %%  Hyperlinks:
-%%     The eprint and doi bibtex fields can be over-ridden in your tex file.
-%%     One reason you might want to do this is to make them hyperlinks.
-%%     The commands to include for this are:
-%%     \newcommand{\eprint}[1]{\href{http://arxiv.org/abs/#1}{arXiv:#1}}
-%%     \newcommand{\doi}[1]{\href{http://dx.doi.org/#1}{doi:#1}}
+%%     To make the eprint and doi bibtex fields hyperlinks, you need
+%%     to have \usepackage{hyperref} in your latex preamble.
 
 %%  Authors:
 %%     John P. Sleath (MRAO)
@@ -1527,9 +1524,11 @@ FUNCTION {begin.bib}
   if$
   "\begin{thebibliography}{}"
     write$ newline$           % no labels in apalike
-  "  \providecommand{\doi}[1]{doi:#1}"
+  " \providecommand{\href}[2]{#2} "
     write$ newline$
-  "  \providecommand{\eprint}[1]{arXiv:#1}"
+  "  \providecommand{\doi}[1]{\href{http://dx.doi.org/#1}{doi:#1}}"
+    write$ newline$
+  "  \providecommand{\eprint}[1]{\href{http://arxiv.org/abs/#1}{arXiv:#1}}"
     write$ newline$
 }
 


### PR DESCRIPTION
Updated version that adds arXiv:1209.1234 and doi:10.0.0/XXXX to the reference list. 
For now, the style can be over-ridden by redefining \eprint and \doi in the user's
tex file to be a hyperlink, but this is not done by default.

Following our discussion, this does not use the adsurl field - one additional complication with them is that they can contain '%' characters - eg, an A&A reference will contain A%26A, which makes them difficult to reliably include in LaTeX.
