### PR TITLE
case-insensitive sorting of surnames starting with de ten van in the …

### DIFF
--- a/mnras.bst
+++ b/mnras.bst
@@ -1776,7 +1776,7 @@ REVERSE {reverse.pass}
 %
 % This is for the second sorting pass.
 FUNCTION {bib.sort.order}
-{ sort.label
+{ sort.label sortify
   "    "
   *
   year field.or.null sortify


### PR DESCRIPTION
Make sorting in the list of references case-insensitive as appears to be the MNRAS house style: the surnames starting with "de " appear next to "D", "van " next to "V" etc.

Here is an example of how the references are ordered in a published MNRAS paper that I'm trying to reproduce with the modified `mnras.bst` (note "de Diego" and "de Jager"): ![mnras_de_refs](https://user-images.githubusercontent.com/42295873/206555037-c75412a9-8fd4-4783-b4d8-2d952b8b1224.png)
